### PR TITLE
Added some regex to the Hilbert, hilb, hilbert.matrix to make them fail only when they exist as functions

### DIFF
--- a/Labs/Tests/Tasks/hilbert_matrix_tests.R
+++ b/Labs/Tests/Tasks/hilbert_matrix_tests.R
@@ -43,28 +43,28 @@ test_that("hilbert_matrix()", {
   
   
   expect_false(body_contain(object = hilbert_matrix,expected = "Hilbert\\s*\\(.*\\)$"),
-              info = "Fel: Funktionen Hilbert() används i funktionen.")
+               info = "Fel: Funktionen Hilbert() används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "hilbert.matrix\\s*\\(.*\\)$"),
-              info = "Fel: Funktionen hilbert.matrix() används i funktionen.")
+               info = "Fel: Funktionen hilbert.matrix() används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "hilb\\s*\\(.*\\)$"),
-              info = "Fel: Funktionen hilb() används i funktionen.")
+               info = "Fel: Funktionen hilb() används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "Matrix"),
-              info = "Fel: Funktioner ur paketet Matrix används i funktionen.")
+               info = "Fel: Funktioner ur paketet Matrix används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "matrixcalc"),
-              info = "Fel: Funktioner ur paketet matrixcalc används i funktionen.")
+               info = "Fel: Funktioner ur paketet matrixcalc används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "pracma"),
-              info = "Fel: Funktioner ur paketet pracma används i funktionen.")
+               info = "Fel: Funktioner ur paketet pracma används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "pbdDMAT"),
-              info = "Fel: Funktioner ur paketet pbdDMAT används i funktionen.")
+               info = "Fel: Funktioner ur paketet pbdDMAT används i funktionen.")
 
   expect_false(body_contain(object = hilbert_matrix,expected = "hilbert\\s*\\(.*\\)$"),
-              info = "Fel: Funktionen/namnet/texten hilbert får inte används i funktionen.")
+               info = "Fel: Funktionen/namnet/texten hilbert får inte används i funktionen.")
 
   # lägg in test för Hilbert (Matrix)hilbert.matrix (matrixcalc), hilb (pracma), Hilbert (pbdDMAT)
   

--- a/Labs/Tests/Tasks/hilbert_matrix_tests.R
+++ b/Labs/Tests/Tasks/hilbert_matrix_tests.R
@@ -42,30 +42,30 @@ test_that("hilbert_matrix()", {
                        info = "Fel: return() saknas i funktionen.")
   
   
-  expect_false(body_contain(object = hilbert_matrix,expected = "Hilbert"),
-               info = "Fel: Funktionen Hilbert() används i funktionen.")
-  
-  expect_false(body_contain(object = hilbert_matrix,expected = "hilbert.matrix"),
-               info = "Fel: Funktionen hilbert.matrix() används i funktionen.")
-  
-  expect_false(body_contain(object = hilbert_matrix,expected = "hilb"),
-               info = "Fel: Funktionen hilb() används i funktionen.")
-  
+  expect_false(body_contain(object = hilbert_matrix,expected = "Hilbert\\s*\\(.*\\)$"),
+              info = "Fel: Funktionen Hilbert() används i funktionen.")
+
+  expect_false(body_contain(object = hilbert_matrix,expected = "hilbert.matrix\\s*\\(.*\\)$"),
+              info = "Fel: Funktionen hilbert.matrix() används i funktionen.")
+
+  expect_false(body_contain(object = hilbert_matrix,expected = "hilb\\s*\\(.*\\)$"),
+              info = "Fel: Funktionen hilb() används i funktionen.")
+
   expect_false(body_contain(object = hilbert_matrix,expected = "Matrix"),
-               info = "Fel: Funktioner ur paketet Matrix används i funktionen.")
-  
+              info = "Fel: Funktioner ur paketet Matrix används i funktionen.")
+
   expect_false(body_contain(object = hilbert_matrix,expected = "matrixcalc"),
-               info = "Fel: Funktioner ur paketet matrixcalc används i funktionen.")
-  
+              info = "Fel: Funktioner ur paketet matrixcalc används i funktionen.")
+
   expect_false(body_contain(object = hilbert_matrix,expected = "pracma"),
-               info = "Fel: Funktioner ur paketet pracma används i funktionen.")
-  
+              info = "Fel: Funktioner ur paketet pracma används i funktionen.")
+
   expect_false(body_contain(object = hilbert_matrix,expected = "pbdDMAT"),
-               info = "Fel: Funktioner ur paketet pbdDMAT används i funktionen.")
-  
-  expect_false(body_contain(object = hilbert_matrix,expected = "hilbert"),
-               info = "Fel: Funktionen/namnet/texten hilbert får inte används i funktionen.")
-  
+              info = "Fel: Funktioner ur paketet pbdDMAT används i funktionen.")
+
+  expect_false(body_contain(object = hilbert_matrix,expected = "hilbert\\s*\\(.*\\)$"),
+              info = "Fel: Funktionen/namnet/texten hilbert får inte används i funktionen.")
+
   # lägg in test för Hilbert (Matrix)hilbert.matrix (matrixcalc), hilb (pracma), Hilbert (pbdDMAT)
   
   # lägg till test för return()!


### PR DESCRIPTION
This will not make the test fail if someone wanted to call a variable 'hilb ' or  'Hilbert', they will only fail when someone call the Hilbert, hilb, hilbert or hilbert.matrix  functions.